### PR TITLE
Add background property by means of hook

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -8,6 +8,13 @@ import { useIsIframe } from './custom-hooks/useIsIframe';
 
 function App() {
   const isIframe = useIsIframe();
+
+  // Remove background if embedded in iframe on external site
+  const bodyElement = document.querySelector('body');
+  if (isIframe) {
+    bodyElement?.style.setProperty('background', 'None');
+  }
+
   return (
     <>
       {!isIframe && <Navbar />}


### PR DESCRIPTION
# Problem

When rendered inside an iFrame, the background should be removed, so it matches better with the host site.

# Solution

We have an IFrame hook which detects whether the page is hosted inside an iFrame or not. In App.js, we run this hook an set the property accordingly.