### PR TITLE
fix: Name immage inside docker-compose.yml

### DIFF
--- a/docker-compose.production.yml
+++ b/docker-compose.production.yml
@@ -36,8 +36,8 @@ services:
 
   frontend:
     container_name: web3_frontend_prod
-    # build:
-    #   context: ./frontend
+    build:
+      context: ./frontend
     image: loxosceles/web3_snapshot_dashboard-frontend:latest
     ports:
       - 80:80
@@ -93,7 +93,6 @@ volumes:
   database:
   certbot_www:
   certbot_conf:
-
 
 networks:
   w3s-nw:


### PR DESCRIPTION
# Problem

We can build a production image for the frontend with docker-compose but we need have the build context and the image property set inside the docker-compose.

# Solution

Do the above